### PR TITLE
Remove buildkit init timeout

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -298,16 +298,13 @@ func (cli *DaemonCli) start(opts *daemonOptions) (err error) {
 
 	log.G(ctx).Info("Daemon has completed initialization")
 
-	routerCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	// Get a the current daemon config, because the daemon sets up config
 	// during initialization. We cannot user the cli.Config for that reason,
 	// as that only holds the config that was set by the user.
 	//
 	// FIXME(thaJeztah): better separate runtime and config data?
 	daemonCfg := d.Config()
-	routerOptions, err := newRouterOptions(routerCtx, &daemonCfg, d)
+	routerOptions, err := newRouterOptions(ctx, &daemonCfg, d)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Buildkit *can* take a long time to start, we don't want the daemon to fail to startup because buildkit took too long.


(cherry picked from commit b7f43c3729c8a46491d0b103cfd1a75ca2fd08cc)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

